### PR TITLE
feat: build olympic dashboard interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,66 @@
-# OlympicGamesStarter
+# Olympic Games Dashboard
 
-This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 18.0.3.
+An interactive Angular dashboard that showcases the medal history of countries from previous Olympic Games. The application was designed to match the provided wireframes and to work seamlessly on desktop and mobile screens.
 
-Don't forget to install your node_modules before starting (`npm install`).
+## Features
 
-## Development server
+- **Dashboard overview** with the total number of Olympic editions and participating countries.
+- **Interactive pie chart** displaying the number of medals per country (click a country to open its detailed view).
+- **Country detail page** with key metrics and a line chart showing the evolution of medals through the years.
+- Responsive layout with accessible UI states for loading and error handling.
 
-Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The application will automatically reload if you change any of the source files.
+## Getting started
 
-## Build
+### Prerequisites
 
-Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory.
+- [Node.js](https://nodejs.org/) version 18 or higher (LTS recommended)
+- [npm](https://www.npmjs.com/) version 9 or higher
 
-## Where to start
+### Installation
 
-As you can see, an architecture has already been defined for the project. It is just a suggestion, you can choose to use your own. The predefined architecture includes (in addition to the default angular architecture) the following:
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Launch the development server:
+   ```bash
+   npm start
+   ```
+3. Open your browser at [http://localhost:4200](http://localhost:4200).
 
-- `components` folder: contains every reusable components
-- `pages` folder: contains components used for routing
-- `core` folder: contains the business logic (`services` and `models` folders)
+The application automatically reloads when a source file is updated.
 
-I suggest you to start by understanding this starter code. Pay an extra attention to the `app-routing.module.ts` and the `olympic.service.ts`.
+### Available scripts
 
-Once mastered, you should continue by creating the typescript interfaces inside the `models` folder. As you can see I already created two files corresponding to the data included inside the `olympic.json`. With your interfaces, improve the code by replacing every `any` by the corresponding interface.
+- `npm start` – Start the local development server.
+- `npm run build` – Build the project for production in the `dist/` directory.
+- `npm test` – Run the unit tests with Karma.
 
-You're now ready to implement the requested features.
+## Project structure
 
-Good luck!
+```
+src/
+├── app/
+│   ├── core/            # Models and services
+│   ├── pages/
+│   │   ├── home/        # Dashboard (pie chart) page
+│   │   ├── country-details/ # Detail (line chart) page
+│   │   └── not-found/
+│   ├── app-routing.module.ts
+│   └── app.module.ts
+└── assets/mock/         # Olympic data source
+```
+
+The Olympic dataset is stored under `src/assets/mock/olympic.json`. The `OlympicService` handles data retrieval and exposes typed observables to the application.
+
+## Tech stack
+
+- [Angular 18](https://angular.io/)
+- [ng2-charts](https://valor-software.com/ng2-charts/) & [Chart.js](https://www.chartjs.org/) for data visualisation
+- [RxJS](https://rxjs.dev/) for reactive data flows
+
+## Notes
+
+- All HTTP calls are encapsulated in Angular services following best practices.
+- Observables are consumed via the `async` pipe to avoid manual subscriptions.
+- The codebase is fully typed with dedicated interfaces for Olympic countries and participations.

--- a/angular.json
+++ b/angular.json
@@ -103,5 +103,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@angular/animations": "^18.0.3",
+        "@angular/cdk": "^18.2.14",
         "@angular/common": "^18.0.3",
         "@angular/compiler": "^18.0.3",
         "@angular/core": "^18.0.3",
@@ -16,6 +17,8 @@
         "@angular/platform-browser": "^18.0.3",
         "@angular/platform-browser-dynamic": "^18.0.3",
         "@angular/router": "^18.0.3",
+        "chart.js": "^4.4.4",
+        "ng2-charts": "^5.0.4",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.3"
@@ -351,6 +354,23 @@
         "tailwindcss": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@angular/cdk": {
+      "version": "18.2.14",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-18.2.14.tgz",
+      "integrity": "sha512-vDyOh1lwjfVk9OqoroZAP8pf3xxKUvyl+TVR8nJxL4c5fOfUFkD7l94HaanqKSRwJcI2xiztuu92IVoHn8T33Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "optionalDependencies": {
+        "parse5": "^7.1.2"
+      },
+      "peerDependencies": {
+        "@angular/common": "^18.0.0 || ^19.0.0",
+        "@angular/core": "^18.0.0 || ^19.0.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/cli": {
@@ -3271,6 +3291,12 @@
         "tslib": "2"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
@@ -5403,6 +5429,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/chart.js": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.4.tgz",
+      "integrity": "sha512-emICKGBABnxhMjUjlYRR12PmOXhJ2eJjEHL2/dZlWjxRAZT1D8xplLFq5M0tMQK8ja+wBS/tuVEJB5C6r7VxJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -6502,7 +6540,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -8933,6 +8971,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -9642,6 +9686,24 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ng2-charts": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/ng2-charts/-/ng2-charts-5.0.4.tgz",
+      "integrity": "sha512-AnOZ2KSRw7QjiMMNtXz9tdnO+XrIKP/2MX1TfqEEo2fwFU5c8LFJIYqmkMPkIzAEm/U9y/1psA5TDNmxxjEdgA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "^4.17.15",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/cdk": ">=16.0.0",
+        "@angular/common": ">=16.0.0",
+        "@angular/core": ">=16.0.0",
+        "@angular/platform-browser": ">=16.0.0",
+        "chart.js": "^3.4.0 || ^4.0.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
     },
     "node_modules/nice-napi": {
       "version": "1.0.2",
@@ -10388,7 +10450,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
       "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^4.4.0"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "private": true,
   "dependencies": {
     "@angular/animations": "^18.0.3",
+    "@angular/cdk": "^18.2.14",
     "@angular/common": "^18.0.3",
     "@angular/compiler": "^18.0.3",
     "@angular/core": "^18.0.3",
@@ -18,6 +19,8 @@
     "@angular/platform-browser": "^18.0.3",
     "@angular/platform-browser-dynamic": "^18.0.3",
     "@angular/router": "^18.0.3",
+    "chart.js": "^4.4.4",
+    "ng2-charts": "^5.0.4",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.3"

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -2,11 +2,16 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { HomeComponent } from './pages/home/home.component';
 import { NotFoundComponent } from './pages/not-found/not-found.component';
+import { CountryDetailsComponent } from './pages/country-details/country-details.component';
 
 const routes: Routes = [
   {
     path: '',
     component: HomeComponent,
+  },
+  {
+    path: 'country/:id',
+    component: CountryDetailsComponent,
   },
   {
     path: '**', // wildcard

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,35 +1,37 @@
 import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
+import { OlympicService } from './core/services/olympic.service';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
+  const loadInitialDataSpy = jasmine
+    .createSpy('loadInitialData')
+    .and.returnValue(of(null));
+
   beforeEach(async () => {
+    loadInitialDataSpy.calls.reset();
+
     await TestBed.configureTestingModule({
-      imports: [
-        RouterTestingModule
-      ],
-      declarations: [
-        AppComponent
+      imports: [RouterTestingModule],
+      declarations: [AppComponent],
+      providers: [
+        {
+          provide: OlympicService,
+          useValue: {
+            loadInitialData: loadInitialDataSpy,
+          },
+        },
       ],
     }).compileComponents();
   });
 
-  it('should create the app', () => {
+  it('should create the app and trigger data loading', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
-    expect(app).toBeTruthy();
-  });
-
-  it(`should have as title 'olympic-games-starter'`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('olympic-games-starter');
-  });
-
-  it('should render title', () => {
-    const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('.content span')?.textContent).toContain('olympic-games-starter app is running!');
+
+    expect(app).toBeTruthy();
+    expect(loadInitialDataSpy).toHaveBeenCalled();
   });
 });

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,14 +1,16 @@
 import { HttpClientModule } from '@angular/common/http';
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { NgChartsModule } from 'ng2-charts';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { HomeComponent } from './pages/home/home.component';
 import { NotFoundComponent } from './pages/not-found/not-found.component';
+import { CountryDetailsComponent } from './pages/country-details/country-details.component';
 
 @NgModule({
-  declarations: [AppComponent, HomeComponent, NotFoundComponent],
-  imports: [BrowserModule, AppRoutingModule, HttpClientModule],
+  declarations: [AppComponent, HomeComponent, NotFoundComponent, CountryDetailsComponent],
+  imports: [BrowserModule, AppRoutingModule, HttpClientModule, NgChartsModule],
   providers: [],
   bootstrap: [AppComponent],
 })

--- a/src/app/core/models/Olympic.ts
+++ b/src/app/core/models/Olympic.ts
@@ -1,9 +1,7 @@
-// TODO: create here a typescript interface for an olympic country
-/*
-example of an olympic country:
-{
-    id: 1,
-    country: "Italy",
-    participations: []
+import { Participation } from './Participation';
+
+export interface Olympic {
+  id: number;
+  country: string;
+  participations: Participation[];
 }
-*/

--- a/src/app/core/models/Participation.ts
+++ b/src/app/core/models/Participation.ts
@@ -1,11 +1,7 @@
-// TODO: create here a typescript interface for a participation
-/*
-example of participation:
-{
-    id: 1,
-    year: 2012,
-    city: "Londres",
-    medalsCount: 28,
-    athleteCount: 372
+export interface Participation {
+  id: number;
+  year: number;
+  city: string;
+  medalsCount: number;
+  athleteCount: number;
 }
-*/

--- a/src/app/core/services/olympic.service.ts
+++ b/src/app/core/services/olympic.service.ts
@@ -1,31 +1,46 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { BehaviorSubject } from 'rxjs';
-import { catchError, tap } from 'rxjs/operators';
+import { BehaviorSubject, Observable, of } from 'rxjs';
+import { catchError, map, tap } from 'rxjs/operators';
+import { Olympic } from '../models/Olympic';
 
 @Injectable({
   providedIn: 'root',
 })
 export class OlympicService {
   private olympicUrl = './assets/mock/olympic.json';
-  private olympics$ = new BehaviorSubject<any>(undefined);
+  private olympics$ = new BehaviorSubject<Olympic[] | null | undefined>(
+    undefined
+  );
 
   constructor(private http: HttpClient) {}
 
-  loadInitialData() {
-    return this.http.get<any>(this.olympicUrl).pipe(
+  loadInitialData(): Observable<Olympic[] | null> {
+    return this.http.get<Olympic[]>(this.olympicUrl).pipe(
       tap((value) => this.olympics$.next(value)),
-      catchError((error, caught) => {
+      catchError((error) => {
         // TODO: improve error handling
         console.error(error);
         // can be useful to end loading state and let the user know something went wrong
         this.olympics$.next(null);
-        return caught;
+        return of(null);
       })
     );
   }
 
-  getOlympics() {
+  getOlympics(): Observable<Olympic[] | null | undefined> {
     return this.olympics$.asObservable();
+  }
+
+  getOlympicById(id: number): Observable<Olympic | undefined | null> {
+    return this.olympics$.pipe(
+      map((olympics) => {
+        if (!olympics || olympics === null) {
+          return olympics;
+        }
+
+        return olympics.find((olympic) => olympic.id === id);
+      })
+    );
   }
 }

--- a/src/app/pages/country-details/country-details.component.html
+++ b/src/app/pages/country-details/country-details.component.html
@@ -1,0 +1,60 @@
+<section class="details" *ngIf="viewModel$ | async as view">
+  <ng-container [ngSwitch]="view.status">
+    <p class="state-message" *ngSwitchCase="'loading'" aria-live="polite">
+      Loading country data...
+    </p>
+
+    <p
+      class="state-message state-message--error"
+      *ngSwitchCase="'error'"
+      role="alert"
+    >
+      We were unable to load the information for this country. Please try again
+      later.
+    </p>
+
+    <div class="state-message" *ngSwitchCase="'not-found'">
+      <p class="state-message__title">Country not found</p>
+      <p class="state-message__body">
+        The requested country does not exist in our records.
+      </p>
+      <a class="link" routerLink="/">Back to dashboard</a>
+    </div>
+
+    <div *ngSwitchCase="'ready'" class="details__card" aria-live="polite">
+      <div class="details__top-bar">
+        <button type="button" class="back-button" routerLink="/">
+          ← Back
+        </button>
+      </div>
+
+      <header class="details__header">
+        <h1 class="details__title">{{ view.countryName }}</h1>
+        <div class="details__metrics" aria-label="Country statistics">
+          <article class="metric">
+            <span class="metric__label">Number of entries</span>
+            <span class="metric__value">{{ view.metrics.entries }}</span>
+          </article>
+          <article class="metric">
+            <span class="metric__label">Total number medals</span>
+            <span class="metric__value">{{ view.metrics.medals }}</span>
+          </article>
+          <article class="metric">
+            <span class="metric__label">Total number of athletes</span>
+            <span class="metric__value">{{ view.metrics.athletes }}</span>
+          </article>
+        </div>
+      </header>
+
+      <div class="details__chart">
+        <canvas
+          baseChart
+          aria-label="Line chart showing the total medals obtained over time"
+          [type]="'line'"
+          [data]="view.chartData"
+          [options]="lineChartOptions"
+        ></canvas>
+      </div>
+    </div>
+  </ng-container>
+</section>

--- a/src/app/pages/country-details/country-details.component.scss
+++ b/src/app/pages/country-details/country-details.component.scss
@@ -1,0 +1,139 @@
+:host {
+  display: block;
+  padding: 2.5rem 1.5rem 3rem;
+}
+
+.details {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.details__card {
+  background: #ffffff;
+  border-radius: 24px;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
+  padding: 2rem 1.75rem 2.5rem;
+  display: grid;
+  gap: 2rem;
+}
+
+.details__top-bar {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.back-button {
+  appearance: none;
+  background: none;
+  border: none;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #2563eb;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  transition: background-color 0.2s ease;
+}
+
+.back-button:hover,
+.back-button:focus-visible {
+  background-color: rgba(37, 99, 235, 0.1);
+  outline: none;
+}
+
+.details__header {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.details__title {
+  margin: 0;
+  font-size: clamp(1.9rem, 2vw + 1rem, 2.6rem);
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.details__metrics {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.metric {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(125, 221, 211, 0.12));
+  border-radius: 18px;
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.metric__label {
+  font-size: 0.95rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #64748b;
+}
+
+.metric__value {
+  font-size: clamp(1.8rem, 1rem + 1.5vw, 2.5rem);
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.details__chart {
+  position: relative;
+  min-height: 360px;
+}
+
+.state-message {
+  max-width: 720px;
+  margin: 4rem auto 0;
+  padding: 1.5rem 2rem;
+  border-radius: 18px;
+  background: #f1f5f9;
+  color: #0f172a;
+  text-align: center;
+  font-size: 1.1rem;
+}
+
+.state-message--error {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.state-message__title {
+  font-weight: 700;
+  font-size: 1.4rem;
+  margin-bottom: 0.25rem;
+}
+
+.state-message__body {
+  margin: 0 0 1rem;
+  color: #475569;
+}
+
+.link {
+  color: #2563eb;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.link:hover,
+.link:focus-visible {
+  text-decoration: underline;
+  outline: none;
+}
+
+@media (min-width: 768px) {
+  :host {
+    padding: 3rem;
+  }
+
+  .details__card {
+    padding: 3rem 3.5rem;
+  }
+}

--- a/src/app/pages/country-details/country-details.component.spec.ts
+++ b/src/app/pages/country-details/country-details.component.spec.ts
@@ -1,19 +1,20 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NgChartsModule } from 'ng2-charts';
 import { of } from 'rxjs';
 import { OlympicService } from 'src/app/core/services/olympic.service';
 
-import { HomeComponent } from './home.component';
+import { CountryDetailsComponent } from './country-details.component';
 
-describe('HomeComponent', () => {
-  let component: HomeComponent;
-  let fixture: ComponentFixture<HomeComponent>;
+describe('CountryDetailsComponent', () => {
+  let component: CountryDetailsComponent;
+  let fixture: ComponentFixture<CountryDetailsComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [RouterTestingModule, NgChartsModule],
-      declarations: [HomeComponent],
+      declarations: [CountryDetailsComponent],
       providers: [
         {
           provide: OlympicService,
@@ -21,10 +22,16 @@ describe('HomeComponent', () => {
             getOlympics: () => of(undefined),
           },
         },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            paramMap: of(convertToParamMap({ id: '1' })),
+          },
+        },
       ],
     }).compileComponents();
 
-    fixture = TestBed.createComponent(HomeComponent);
+    fixture = TestBed.createComponent(CountryDetailsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/src/app/pages/country-details/country-details.component.ts
+++ b/src/app/pages/country-details/country-details.component.ts
@@ -1,0 +1,196 @@
+import { Component } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import {
+  CategoryScale,
+  Chart,
+  ChartData,
+  ChartOptions,
+  Legend,
+  LineElement,
+  LinearScale,
+  PointElement,
+  Tooltip,
+} from 'chart.js';
+import { combineLatest, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { Participation } from 'src/app/core/models/Participation';
+import { OlympicService } from 'src/app/core/services/olympic.service';
+
+Chart.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
+
+interface CountryDetailsViewModel {
+  status: 'loading' | 'error' | 'not-found' | 'ready';
+  countryName: string;
+  chartData: ChartData<'line'>;
+  metrics: {
+    entries: number;
+    medals: number;
+    athletes: number;
+  };
+}
+
+@Component({
+  selector: 'app-country-details',
+  templateUrl: './country-details.component.html',
+  styleUrls: ['./country-details.component.scss'],
+})
+export class CountryDetailsComponent {
+  private readonly emptyLineChartData: ChartData<'line'> = {
+    labels: [],
+    datasets: [],
+  };
+
+  public readonly lineChartOptions: ChartOptions<'line'> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        callbacks: {
+          label: (context) => {
+            const value =
+              typeof context.parsed === 'number'
+                ? context.parsed
+                : context.parsed.y;
+
+            return `${value} medals`;
+          },
+        },
+      },
+    },
+    scales: {
+      x: {
+        title: {
+          display: true,
+          text: 'Dates',
+          color: '#475569',
+        },
+        ticks: {
+          color: '#475569',
+        },
+        grid: {
+          color: 'rgba(148, 163, 184, 0.2)',
+        },
+      },
+      y: {
+        title: {
+          display: true,
+          text: 'Number of medals',
+          color: '#475569',
+        },
+        ticks: {
+          color: '#475569',
+        },
+        grid: {
+          color: 'rgba(148, 163, 184, 0.2)',
+        },
+        beginAtZero: true,
+      },
+    },
+    interaction: {
+      mode: 'index',
+      intersect: false,
+    },
+  };
+
+  public readonly viewModel$: Observable<CountryDetailsViewModel> = combineLatest([
+    this.route.paramMap.pipe(
+      map((params) => {
+        const rawId = params.get('id');
+        if (rawId === null) {
+          return null;
+        }
+
+        const parsed = Number(rawId);
+        return Number.isNaN(parsed) ? null : parsed;
+      })
+    ),
+    this.olympicService.getOlympics(),
+  ]).pipe(
+    map(([countryId, olympics]): CountryDetailsViewModel => {
+      if (olympics === null) {
+        return {
+          status: 'error' as const,
+          countryName: '',
+          chartData: this.emptyLineChartData,
+          metrics: { entries: 0, medals: 0, athletes: 0 },
+        };
+      }
+
+      if (!olympics) {
+        return {
+          status: 'loading' as const,
+          countryName: '',
+          chartData: this.emptyLineChartData,
+          metrics: { entries: 0, medals: 0, athletes: 0 },
+        };
+      }
+
+      if (countryId === null) {
+        return {
+          status: 'not-found' as const,
+          countryName: '',
+          chartData: this.emptyLineChartData,
+          metrics: { entries: 0, medals: 0, athletes: 0 },
+        };
+      }
+
+      const country = olympics.find((olympic) => olympic.id === countryId);
+
+      if (!country) {
+        return {
+          status: 'not-found' as const,
+          countryName: '',
+          chartData: this.emptyLineChartData,
+          metrics: { entries: 0, medals: 0, athletes: 0 },
+        };
+      }
+
+      const participations: Participation[] = [...country.participations].sort(
+        (a, b) => a.year - b.year
+      );
+
+      const chartData: ChartData<'line'> = {
+        labels: participations.map((participation) => participation.year.toString()),
+        datasets: [
+          {
+            data: participations.map((participation) => participation.medalsCount),
+            label: 'Total medals',
+            borderColor: '#2563EB',
+            backgroundColor: 'rgba(37, 99, 235, 0.15)',
+            pointBackgroundColor: '#1D4ED8',
+            pointHoverRadius: 6,
+            pointRadius: 5,
+            tension: 0.35,
+            fill: true,
+          },
+        ],
+      };
+
+      const medals = participations.reduce(
+        (total, participation) => total + participation.medalsCount,
+        0
+      );
+      const athletes = participations.reduce(
+        (total, participation) => total + participation.athleteCount,
+        0
+      );
+
+      return {
+        status: 'ready' as const,
+        countryName: country.country,
+        chartData,
+        metrics: {
+          entries: participations.length,
+          medals,
+          athletes,
+        },
+      };
+    })
+  );
+
+  constructor(
+    private readonly olympicService: OlympicService,
+    private readonly route: ActivatedRoute
+  ) {}
+}

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -1,3 +1,64 @@
-<h2>Olympic games app</h2>
-<hr />
-<p>{{ (olympics$ | async)?.length }} data loaded</p>
+<section class="home" *ngIf="homeView$ | async as view">
+  <ng-container [ngSwitch]="view.status">
+    <p *ngSwitchCase="'loading'" class="state-message" aria-live="polite">
+      Loading Olympic data...
+    </p>
+
+    <p
+      *ngSwitchCase="'error'"
+      class="state-message state-message--error"
+      role="alert"
+    >
+      An error occurred while loading the Olympic data. Please try again later.
+    </p>
+
+    <div *ngSwitchCase="'ready'" class="dashboard" aria-live="polite">
+      <header class="dashboard__header">
+        <h1 class="dashboard__title">Medals per Country</h1>
+        <div class="dashboard__stats" aria-label="Global statistics">
+          <article class="stat-card" aria-label="Number of Olympic games shown">
+            <span class="stat-card__label">Number of JOs</span>
+            <span class="stat-card__value">{{ view.totalGames }}</span>
+          </article>
+          <article class="stat-card" aria-label="Number of represented countries">
+            <span class="stat-card__label">Number of countries</span>
+            <span class="stat-card__value">{{ view.totalCountries }}</span>
+          </article>
+        </div>
+      </header>
+
+      <div class="dashboard__chart">
+        <canvas
+          baseChart
+          aria-label="Pie chart showing the number of medals won per country"
+          [type]="'pie'"
+          [data]="view.chartData"
+          [options]="pieChartOptions"
+          (chartClick)="onChartClick($event)"
+        ></canvas>
+      </div>
+
+      <p class="dashboard__hint">
+        Click on a country slice or use the buttons below to explore its Olympic
+        history.
+      </p>
+
+      <div class="dashboard__actions" role="navigation" aria-label="Country navigation">
+        <button
+          type="button"
+          class="country-pill"
+          *ngFor="let country of view.countries"
+          (click)="goToCountry(country.id)"
+        >
+          {{ country.name }}
+        </button>
+      </div>
+
+      <ul class="sr-only" aria-label="Medals per country list">
+        <li *ngFor="let country of view.countries">
+          {{ country.name }}: {{ country.totalMedals }} medals
+        </li>
+      </ul>
+    </div>
+  </ng-container>
+</section>

--- a/src/app/pages/home/home.component.scss
+++ b/src/app/pages/home/home.component.scss
@@ -1,0 +1,148 @@
+:host {
+  display: block;
+  padding: 2.5rem 1.5rem 3rem;
+}
+
+.home {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.dashboard {
+  background: #ffffff;
+  border-radius: 24px;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
+  padding: 2.5rem 2rem;
+  display: grid;
+  gap: 2rem;
+}
+
+.dashboard__header {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.dashboard__title {
+  font-size: clamp(1.8rem, 2vw + 1rem, 2.6rem);
+  font-weight: 700;
+  color: #0f172a;
+  margin: 0;
+}
+
+.dashboard__stats {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.stat-card {
+  background: linear-gradient(135deg, rgba(1, 176, 185, 0.1), rgba(96, 165, 250, 0.1));
+  border-radius: 18px;
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.stat-card__label {
+  font-size: 0.95rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #64748b;
+}
+
+.stat-card__value {
+  font-size: clamp(1.9rem, 1rem + 1.8vw, 2.8rem);
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.dashboard__chart {
+  position: relative;
+  min-height: 320px;
+}
+
+.dashboard__chart canvas {
+  max-width: 100%;
+}
+
+.dashboard__hint {
+  margin: 0;
+  font-size: 1rem;
+  color: #0f172a;
+  font-weight: 500;
+}
+
+.dashboard__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.country-pill {
+  appearance: none;
+  border: none;
+  background: rgba(1, 176, 185, 0.12);
+  color: #0f172a;
+  font-weight: 600;
+  padding: 0.5rem 1.25rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.country-pill:hover,
+.country-pill:focus-visible {
+  background: rgba(1, 176, 185, 0.22);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.state-message {
+  max-width: 720px;
+  margin: 4rem auto 0;
+  padding: 1.5rem 2rem;
+  border-radius: 18px;
+  background: #f1f5f9;
+  color: #0f172a;
+  text-align: center;
+  font-size: 1.1rem;
+}
+
+.state-message--error {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (min-width: 768px) {
+  :host {
+    padding: 3rem;
+  }
+
+  .dashboard {
+    padding: 3rem 3.5rem;
+  }
+
+  .dashboard__header {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .dashboard__title {
+    max-width: 320px;
+  }
+}

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -1,18 +1,195 @@
-import { Component, OnInit } from '@angular/core';
-import { Observable, of } from 'rxjs';
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+import {
+  ActiveElement,
+  ArcElement,
+  Chart,
+  ChartData,
+  ChartEvent,
+  ChartOptions,
+  Legend,
+  Tooltip,
+} from 'chart.js';
+import { Observable } from 'rxjs';
+import { map, tap } from 'rxjs/operators';
 import { OlympicService } from 'src/app/core/services/olympic.service';
+
+Chart.register(ArcElement, Tooltip, Legend);
+
+interface CountryMedal {
+  id: number;
+  name: string;
+  totalMedals: number;
+}
+
+interface HomeViewModel {
+  status: 'loading' | 'error' | 'ready';
+  totalGames: number;
+  totalCountries: number;
+  chartData: ChartData<'pie', number[], string>;
+  countries: CountryMedal[];
+}
 
 @Component({
   selector: 'app-home',
   templateUrl: './home.component.html',
   styleUrls: ['./home.component.scss'],
 })
-export class HomeComponent implements OnInit {
-  public olympics$: Observable<any> = of(null);
+export class HomeComponent {
+  private readonly chartColors = [
+    '#01B0B9',
+    '#7DDDD3',
+    '#F4C095',
+    '#F4978E',
+    '#8E64FF',
+    '#60A5FA',
+  ];
 
-  constructor(private olympicService: OlympicService) {}
+  private countrySegments: CountryMedal[] = [];
 
-  ngOnInit(): void {
-    this.olympics$ = this.olympicService.getOlympics();
+  private readonly emptyPieChartData: ChartData<'pie', number[], string> = {
+    labels: [],
+    datasets: [
+      {
+        data: [],
+        backgroundColor: [],
+        borderColor: '#FFFFFF',
+        borderWidth: 2,
+      },
+    ],
+  };
+
+  public readonly pieChartOptions: ChartOptions<'pie'> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: {
+        position: 'right',
+        labels: {
+          boxWidth: 16,
+          boxHeight: 16,
+          color: '#0F172A',
+          usePointStyle: true,
+        },
+      },
+      tooltip: {
+        callbacks: {
+          label: (context) => `${context.label}: ${context.parsed} medals`,
+        },
+      },
+    },
+  };
+
+  public readonly homeView$: Observable<HomeViewModel> = this.olympicService
+    .getOlympics()
+    .pipe(
+      map((olympics): HomeViewModel => {
+        if (olympics === null) {
+          return {
+            status: 'error' as const,
+            totalGames: 0,
+            totalCountries: 0,
+            chartData: this.emptyPieChartData,
+            countries: [],
+          };
+        }
+
+        if (!olympics) {
+          return {
+            status: 'loading' as const,
+            totalGames: 0,
+            totalCountries: 0,
+            chartData: this.emptyPieChartData,
+            countries: [],
+          };
+        }
+
+        const countries: CountryMedal[] = olympics.map((olympic) => ({
+          id: olympic.id,
+          name: olympic.country,
+          totalMedals: olympic.participations.reduce(
+            (total, participation) => total + participation.medalsCount,
+            0
+          ),
+        }));
+
+        const years = new Set<number>();
+        olympics.forEach((olympic) =>
+          olympic.participations.forEach((participation) =>
+            years.add(participation.year)
+          )
+        );
+
+        const chartData: ChartData<'pie', number[], string> = {
+          labels: countries.map((country) => country.name),
+          datasets: [
+            {
+              data: countries.map((country) => country.totalMedals),
+              backgroundColor: countries.map(
+                (_, index) => this.chartColors[index % this.chartColors.length]
+              ),
+              borderColor: '#FFFFFF',
+              borderWidth: 2,
+              hoverOffset: 8,
+            },
+          ],
+        };
+
+        return {
+          status: 'ready' as const,
+          totalGames: years.size,
+          totalCountries: olympics.length,
+          chartData,
+          countries,
+        };
+      }),
+      tap((view) => {
+        if (view.status === 'ready') {
+          this.countrySegments = view.countries;
+        } else {
+          this.countrySegments = [];
+        }
+      })
+    );
+
+  constructor(
+    private readonly olympicService: OlympicService,
+    private readonly router: Router
+  ) {}
+
+  public onChartClick({
+    active,
+  }: {
+    event?: ChartEvent;
+    active?: Array<ActiveElement | object>;
+  }): void {
+    if (!this.isActiveElementArray(active) || active.length === 0) {
+      return;
+    }
+
+    const index = active[0].index;
+    const country = this.countrySegments[index];
+
+    if (country) {
+      this.goToCountry(country.id);
+    }
+  }
+
+  private isActiveElementArray(
+    elements?: Array<ActiveElement | object>
+  ): elements is ActiveElement[] {
+    return (
+      Array.isArray(elements) &&
+      elements.every(
+        (element) =>
+          'index' in element &&
+          'datasetIndex' in element &&
+          typeof element.index === 'number'
+      )
+    );
+  }
+
+  public goToCountry(countryId: number): void {
+    this.router.navigate(['/country', countryId]);
   }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,1 +1,31 @@
-/* You can add global styles to this file, and also import other style files */
+:root {
+  color-scheme: light;
+  font-family: 'Inter', 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  line-height: 1.5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #f7fafc 0%, #edf2f7 100%);
+  color: #0f172a;
+}
+
+a {
+  color: inherit;
+}
+
+button,
+input,
+textarea,
+select {
+  font: inherit;
+}
+
+router-outlet + * {
+  display: block;
+}


### PR DESCRIPTION
## Summary
- type the Olympic data models and improve the data service with typed observables
- build the responsive dashboard and country detail pages with interactive charts
- add charting dependencies and refresh the global styling and README documentation

## Testing
- `CI=1 npm run build`
- `CI=1 npm run test -- --watch=false --browsers=ChromeHeadless` *(fails: Chrome binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c978f0036083318b8f6286f48e51ff