### PR TITLE
Adjust pie chart sizing and label alignment

### DIFF
--- a/src/app/pages/home/home.component.scss
+++ b/src/app/pages/home/home.component.scss
@@ -84,14 +84,15 @@
 }
 
 .chart-card {
-  width: 100%;
+  width: min(100%, 560px);
+  margin: 0 auto;
   border-radius: 1.75rem;
 }
 
 .chart-card__canvas {
   position: relative;
   width: 100%;
-  min-height: 320px;
+  min-height: clamp(260px, 55vw, 400px);
 }
 
 .chart-card__canvas canvas {
@@ -113,7 +114,11 @@
     text-align: center;
   }
 
+  .chart-card {
+    width: 100%;
+  }
+
   .chart-card__canvas {
-    min-height: 280px;
+    min-height: clamp(240px, 65vw, 320px);
   }
 }

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -29,6 +29,14 @@ export class HomeComponent implements OnInit {
   public pieChartOptions: ChartConfiguration<'pie'>['options'] = {
     responsive: true,
     maintainAspectRatio: false,
+    layout: {
+      padding: {
+        top: 24,
+        bottom: 24,
+        left: (context) => Math.min(72, context.chart.width * 0.25),
+        right: (context) => Math.min(72, context.chart.width * 0.25),
+      },
+    },
     plugins: {
       legend: {
         display: false,
@@ -60,11 +68,12 @@ export class HomeComponent implements OnInit {
   private readonly calloutLabelsPlugin: Plugin<'pie'> = {
     id: 'pieCalloutLabels',
     afterDatasetsDraw: (chart) => {
-      const { ctx, data } = chart;
+      const { ctx, data, chartArea } = chart;
       const dataset = data.datasets[0];
       const meta = chart.getDatasetMeta(0);
+      const labelMargin = Math.min(28, chart.width * 0.12);
 
-      if (!dataset || !meta?.data.length) {
+      if (!dataset || !meta?.data.length || !chartArea) {
         return;
       }
 
@@ -84,14 +93,16 @@ export class HomeComponent implements OnInit {
         }
 
         const angle = (startAngle + endAngle) / 2;
-        const radialGap = 14;
-        const horizontalGap = 26;
+        const radialGap = 18;
+        const { left: chartLeft, right: chartRight } = chartArea;
         const startX = centerX + Math.cos(angle) * outerRadius;
         const startY = centerY + Math.sin(angle) * outerRadius;
         const middleX = centerX + Math.cos(angle) * (outerRadius + radialGap);
         const middleY = centerY + Math.sin(angle) * (outerRadius + radialGap);
         const isRightSide = Math.cos(angle) >= 0;
-        const endX = middleX + (isRightSide ? horizontalGap : -horizontalGap);
+        const endX = isRightSide
+          ? chartRight + labelMargin
+          : chartLeft - labelMargin;
         const endY = middleY;
 
         ctx.save();


### PR DESCRIPTION
## Summary
- limit the pie chart card width and responsive height to keep the visualization compact on large screens while remaining fluid
- extend the custom callout label lines to align with the chart edges and include safe guards around the chart area
- add responsive chart padding so the callout label text remains visible within the canvas

## Testing
- npm run test -- --watch=false --browsers=ChromeHeadless *(fails: Cannot find builder "@angular/build:karma")*

------
https://chatgpt.com/codex/tasks/task_e_68cc033432588331b8929ba74d0c59a9