### PR TITLE
Refine pie chart sizing and callout alignment

### DIFF
--- a/src/app/pages/home/home.component.scss
+++ b/src/app/pages/home/home.component.scss
@@ -84,14 +84,15 @@
 }
 
 .chart-card {
-  width: 100%;
+  width: min(100%, 480px);
+  margin: 0 auto;
   border-radius: 1.75rem;
 }
 
 .chart-card__canvas {
   position: relative;
   width: 100%;
-  min-height: 320px;
+  min-height: clamp(240px, 48vw, 360px);
 }
 
 .chart-card__canvas canvas {
@@ -113,7 +114,11 @@
     text-align: center;
   }
 
+  .chart-card {
+    width: 100%;
+  }
+
   .chart-card__canvas {
-    min-height: 280px;
+    min-height: clamp(220px, 60vw, 300px);
   }
 }


### PR DESCRIPTION
## Summary
- shrink the chart card footprint and responsive canvas height so the pie renders more compactly
- expand the pie layout padding and callout plugin math to align label columns to the canvas edges without clipping
- centralize pie dataset creation to keep typing strict while letting the global radius option scale the chart

## Testing
- npm run build *(fails: CountryDetailsComponent is not standalone; Angular CLI cannot resolve chartjs-plugin-datalabels declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68cc033432588331b8929ba74d0c59a9