### PR TITLE
docs: add english version of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,183 @@
 # OlympicGamesStarter
 
-This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 18.0.3.
+## Table of Contents (English)
+- [Overview](#overview)
+- [Prerequisites](#prerequisites)
+- [Installation](#installation)
+- [Running the Application](#running-the-application)
+- [Other Useful Scripts](#other-useful-scripts)
+- [Project Structure](#project-structure)
+- [Quality and Best Practices](#quality-and-best-practices)
+- [Going Further](#going-further)
 
-Don't forget to install your node_modules before starting (`npm install`).
+## Overview
+Welcome to **OlympicGamesStarter**, an Angular application that provides a foundation for visualizing and analyzing Olympic Games results. This project acts as a starter kit for front-end workshops: the entire architecture is ready so you can focus on implementing features.
 
-## Development server
+- **Goal**: deliver an Angular baseline to work with Olympic Games data (available in `src/assets/olympic.json`).
+- **Target audience**: learners who want to get comfortable with Angular 18, consuming JSON data, and setting up a modular architecture.
+- **Core technologies**: Angular 18, TypeScript, RxJS, Jasmine/Karma.
 
-Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The application will automatically reload if you change any of the source files.
+## Prerequisites
+Before you begin, make sure your environment includes:
+- [Node.js](https://nodejs.org/) >= 18
+- [npm](https://www.npmjs.com/) >= 9 (bundled with Node.js)
+- [Angular CLI](https://angular.io/cli) >= 18 (`npm install -g @angular/cli`)
 
-## Build
+## Installation
+1. Clone the repository:
+   ```bash
+   git clone <repository-url>
+   cd OlympicGamesStarter
+   ```
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
 
-Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory.
+## Running the Application
+To start the development server:
+```bash
+npm start
+```
+- The application runs at [http://localhost:4200](http://localhost:4200).
+- Code changes automatically reload the page.
 
-## Where to start
+## Other Useful Scripts
+- **Production build**:
+  ```bash
+  npm run build
+  ```
+  Build artifacts are generated in `dist/`.
+- **Unit tests**:
+  ```bash
+  npm test
+  ```
+  Tests run through Karma.
+- **Lint** *(if you add ESLint to the project)*:
+  ```bash
+  npm run lint
+  ```
 
-As you can see, an architecture has already been defined for the project. It is just a suggestion, you can choose to use your own. The predefined architecture includes (in addition to the default angular architecture) the following:
+## Project Structure
+The project follows a modular architecture designed to separate concerns:
 
-- `components` folder: contains every reusable components
-- `pages` folder: contains components used for routing
-- `core` folder: contains the business logic (`services` and `models` folders)
+```
+src/
+├── app/
+│   ├── core/          # Services, models, and business logic
+│   ├── components/    # Reusable components
+│   ├── pages/         # Page components used in routing
+│   └── app-routing.module.ts
+├── assets/            # Static data (e.g., olympic.json)
+└── environments/      # Environment-specific configuration (create as needed)
+```
 
-I suggest you to start by understanding this starter code. Pay an extra attention to the `app-routing.module.ts` and the `olympic.service.ts`.
+Getting started tips:
+- Open `app/app-routing.module.ts` to understand the routing setup.
+- Review `app/core/services/olympic.service.ts` to see how data is loaded.
+- Create your TypeScript interfaces in `app/core/models/` and replace `any` types with strong typings.
 
-Once mastered, you should continue by creating the typescript interfaces inside the `models` folder. As you can see I already created two files corresponding to the data included inside the `olympic.json`. With your interfaces, improve the code by replacing every `any` by the corresponding interface.
+## Quality and Best Practices
+- Follow Angular naming conventions (PascalCase for components, camelCase for services, etc.).
+- Add unit tests for every new feature.
+- Keep this documentation up to date with notable changes (new scripts, dependencies, etc.).
+- Document major technical decisions in a `docs/` folder or the project wiki if needed.
 
-You're now ready to implement the requested features.
+## Going Further
+- Integrate quality tools (ESLint, Prettier) to automate checks.
+- Describe upcoming features or roadmap items in a `Roadmap` section if the project continues to evolve.
+- Add screenshots or GIFs showcasing key features once they are implemented.
 
-Good luck!
+Happy exploring and coding!
+
+---
+
+## Table des matières (Français)
+- [Présentation](#présentation)
+- [Prérequis](#prérequis)
+- [Installation](#installation)
+- [Lancement de l'application](#lancement-de-lapplication)
+- [Autres scripts utiles](#autres-scripts-utiles)
+- [Structure du projet](#structure-du-projet)
+- [Qualité et bonnes pratiques](#qualité-et-bonnes-pratiques)
+- [Aller plus loin](#aller-plus-loin)
+
+## Présentation
+Bienvenue dans **OlympicGamesStarter**, une application Angular qui propose une base de travail pour visualiser et analyser les résultats des Jeux Olympiques. Ce projet sert de squelette pour les ateliers front-end : toute l'architecture est prête afin de vous concentrer sur l'implémentation des fonctionnalités.
+
+- **Objectif** : fournir un socle Angular pour manipuler les données des Jeux Olympiques (données disponibles dans `src/assets/olympic.json`).
+- **Public visé** : apprenants souhaitant se familiariser avec Angular 18, la consommation de données JSON et la mise en place d'une architecture modulaire.
+- **Technologies principales** : Angular 18, TypeScript, RxJS, Jasmine/Karma.
+
+## Prérequis
+Avant de démarrer, vérifiez que votre environnement dispose des éléments suivants :
+- [Node.js](https://nodejs.org/) >= 18
+- [npm](https://www.npmjs.com/) >= 9 (installé avec Node.js)
+- [Angular CLI](https://angular.io/cli) >= 18 (`npm install -g @angular/cli`)
+
+## Installation
+1. Clonez le dépôt :
+   ```bash
+   git clone <url-du-repo>
+   cd OlympicGamesStarter
+   ```
+2. Installez les dépendances :
+   ```bash
+   npm install
+   ```
+
+## Lancement de l'application
+Pour lancer le serveur de développement :
+```bash
+npm start
+```
+- L'application est disponible sur [http://localhost:4200](http://localhost:4200).
+- Les modifications sur le code rechargent automatiquement la page.
+
+## Autres scripts utiles
+- **Build de production** :
+  ```bash
+  npm run build
+  ```
+  Les artefacts de build sont générés dans `dist/`.
+- **Tests unitaires** :
+  ```bash
+  npm test
+  ```
+  Les tests sont exécutés via Karma.
+- **Lint** *(si vous ajoutez ESLint au projet)* :
+  ```bash
+  npm run lint
+  ```
+
+## Structure du projet
+Le projet suit une architecture modulaire pensée pour séparer les responsabilités :
+
+```
+src/
+├── app/
+│   ├── core/          # Services, modèles et logique métier
+│   ├── components/    # Composants réutilisables
+│   ├── pages/         # Composants de page utilisés dans le routing
+│   └── app-routing.module.ts
+├── assets/            # Données statiques (ex: olympic.json)
+└── environments/      # Configuration selon l'environnement (à créer si besoin)
+```
+
+Quelques conseils pour débuter :
+- Ouvrez `app/app-routing.module.ts` pour comprendre le routing.
+- Étudiez `app/core/services/olympic.service.ts` pour voir comment les données sont chargées.
+- Créez vos interfaces TypeScript dans `app/core/models/` et remplacez les `any` par des types forts.
+
+## Qualité et bonnes pratiques
+- Respectez les conventions de nommage Angular (PascalCase pour les composants, camelCase pour les services, etc.).
+- Ajoutez des tests unitaires pour chaque nouvelle fonctionnalité.
+- Mettez à jour cette documentation à chaque évolution notable (nouveaux scripts, nouvelles dépendances, etc.).
+- Pensez à documenter les décisions techniques importantes dans un `docs/` ou le wiki du projet si nécessaire.
+
+## Aller plus loin
+- Intégrez un outil de vérification (ESLint, Prettier) pour automatiser les contrôles qualité.
+- Décrivez votre roadmap ou vos fonctionnalités à venir dans une section `Roadmap` si le projet continue d'évoluer.
+- Ajoutez des captures d'écran ou GIF montrant les principales fonctionnalités une fois développées.
+
+Bonne exploration et bon développement !


### PR DESCRIPTION
## Summary
- add a full English translation of the README before the French content
- keep the existing French documentation for bilingual guidance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d36e5ecf7483319756f506ff7c98c0