### PR TITLE
Adjust country details layout for small screens

### DIFF
--- a/src/app/pages/country-details/country-details.component.scss
+++ b/src/app/pages/country-details/country-details.component.scss
@@ -41,14 +41,33 @@
   align-items: center;
   flex-wrap: wrap;
   width: 100%;
+
+  @media (max-width: 600px) {
+    gap: 1rem !important;
+
+    .stat-card {
+      width: min(100%, 260px);
+      padding: 0.85rem 1.25rem;
+      border-radius: 1rem;
+    }
+
+    .stat-card__label {
+      font-size: 1.05rem;
+      letter-spacing: 0.08em;
+    }
+
+    .stat-card__value {
+      font-size: 1.6rem;
+      font-weight: 500;
+    }
+  }
 }
 
 .details__chart {
   position: relative;
   width: 100%;
-  height: 400px;
   min-width: 200px;
-  min-height: 500px;
+  height: clamp(320px, 55vw, 460px);
 }
 
 .state-message {

--- a/src/app/pages/country-details/country-details.component.ts
+++ b/src/app/pages/country-details/country-details.component.ts
@@ -42,10 +42,10 @@ export class CountryDetailsComponent implements OnInit
     chartData: this.emptyLineChartData
   });
 
-  public lineChartOptions: ChartConfiguration<'line'>['options'] = 
+  public lineChartOptions: ChartConfiguration<'line'>['options'] =
   {
     responsive: true,
-    maintainAspectRatio: true,
+    maintainAspectRatio: false,
     layout: {
       padding: {
         top: 20,
@@ -63,7 +63,7 @@ export class CountryDetailsComponent implements OnInit
           boxWidth: 0, // On affiche pas les boîtes de couleur
           boxHeight: 0,
           font: {
-            size: 30, 
+            size: 16,
             family: 'Montserrat, sans-serif'
           },
           color: '#898f9bff'
@@ -102,7 +102,7 @@ export class CountryDetailsComponent implements OnInit
           display: true, // Garder les années affichées
           color: '#000000ff',
           font: {
-            size: 14
+            size: 12
           }
         }
       },
@@ -119,7 +119,7 @@ export class CountryDetailsComponent implements OnInit
           display: true, // Supprimer l'affichage des nombres sur l'axe Y
           color: '#000000ff',
           font: {
-            size: 14
+            size: 12
           }
         }
       }


### PR DESCRIPTION
## Summary
- reduce stat card dimensions and typography on the country details page when viewed on narrow screens
- make the medal history chart taller while keeping it responsive and shrink the legend font for better readability
- update chart options to drop aspect ratio constraints so the canvas can fill the new container height

## Testing
- npm test -- --watch=false --browsers=ChromeHeadless *(fails: Angular CLI configuration requires a polyfills array)*

------
https://chatgpt.com/codex/tasks/task_e_68d50a29a8fc8331a13832bd299b1fa9